### PR TITLE
fix: Load user role in protectRoute middleware fixes #1

### DIFF
--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
+import User from '../models/user.js';
 
-export const protectRoute = (req, res, next) => {
+export const protectRoute = async (req, res, next) => {
     try{
         const token = req.headers.authorization?.split(' ')[1];
 
@@ -10,7 +11,15 @@ export const protectRoute = (req, res, next) => {
 
         const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret');
         req.userId = decoded.id;
+        
+        // Load user to get role
+        const user = await User.findById(decoded.id);
+        if (!user){
+            return res.status(401).json({ message: 'User not found'});
+        }
+        req.userRole = user.role;
         next();
+        
     } catch(error){
         return res.status(403).json({ message: 'Invalid token or Expired Token'});
     }

--- a/routes/barberRoutes.js
+++ b/routes/barberRoutes.js
@@ -3,7 +3,7 @@ import { createBarber, getAllBarbers, getBarberById, updateBarber, deleteBarber 
 // import validation script
 import { requireFields } from '../middleware/validateRequest.js';
 // import authentication middleware
-import { protectRoute } from '../middleware/authMiddleware.js';
+import { protectRoute, authorizeRole } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
@@ -15,8 +15,8 @@ router.get('/:id', getBarberById); //order of get requests matters
 router.get('/', getAllBarbers);
 
 // Protected routes - require authentication
-router.post('/', protectRoute, requireFields(['name','email','phone']), createBarber);
-router.put('/:id', protectRoute, updateBarber);
-router.delete('/:id', protectRoute, deleteBarber);
+router.post('/', protectRoute,authorizeRole('admin','barber'), requireFields(['name','email','phone']), createBarber);
+router.put('/:id', protectRoute,authorizeRole('admin','barber'), updateBarber);
+router.delete('/:id', protectRoute,authorizeRole('admin','barber'), deleteBarber);
 
 export default router;


### PR DESCRIPTION
## Changes
This PR fixes the role-based access control issue where req.userRole was undefined.

### What was changed:
- ✅ Added User model import to authMiddleware.js
- ✅ Changed protectRoute to async function
- ✅ Load user from database using token's decoded ID
- ✅ Set req.userRole from fetched user's role field
- ✅ Added validation to return 401 if user not found

## Related Issue
Closes #1

## Testing
- [x] Tested with admin role - can create barbers
- [x] Tested with barber role - can create barbers
- [x] Tested with user role - gets 403 as expected
- [x] Tested with invalid token - gets 403
- [x] Tested without token - gets 401

## Checklist
- [x] Code follows project conventions
- [x] Changes have been tested locally
- [x] No breaking changes introduced